### PR TITLE
chore(actions): remove Terraform Plan step in Actions workflow

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -43,8 +43,8 @@ jobs:
       run: cd terraform/ && terraform validate
   
     # Generates an execution plan for Terraform
-    - name: Terraform Plan
-      run: cd terraform/ && terraform plan -input=false
+    # - name: Terraform Plan
+    #   run: cd terraform/ && terraform plan -input=false
 
       # On push to "main", build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks


### PR DESCRIPTION
Since we've integrated this Github repo with Terraform Cloud, we do not need the steps to plan and apply Terraform configurations as they'll be handled on TF Cloud (which gets triggered on file change detection). This will remove the duplicated planning on TF cloud (see image below).

The steps to format and validate TF configurations have remained to ensure proper testing.

![Screenshot_20240106_192904](https://github.com/chriswachira/chriswachira.com/assets/19710961/3ba83d72-2eaa-424d-812d-147eb05a2723)
