### PR TITLE
fix(terraform): change ACM public certificate key algorithm to the supported bit size 2048

### DIFF
--- a/terraform/aws-acm.tf
+++ b/terraform/aws-acm.tf
@@ -1,7 +1,7 @@
 resource "aws_acm_certificate" "chriswachira_com_certificate" {
   domain_name       = "chriswachira.com"
   validation_method = "DNS"
-  key_algorithm     = "RSA_4096"
+  key_algorithm     = "RSA_2048"
 
   tags = {
     Environment = "Production"


### PR DESCRIPTION
The 4096 bit size is not supported for ACM-generated certificates; only available for imported certificates from other certificate authorities.

https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html#algorithms