### PR TITLE
chore(terraform): migrate chriswachira.com CloudFront distribution to us-east-1 for mapping on Route53

### DIFF
--- a/terraform/aws-cloudfront.tf
+++ b/terraform/aws-cloudfront.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudfront_origin_access_identity" "chriswachira_cf_dist_origin_identity" {
-  comment = "Access identity for the CloudFront distribution for chriswachira.com"
+  comment  = "Access identity for the CloudFront distribution for chriswachira.com"
+  provider = aws.us_east_1
 }
 
 locals {
@@ -7,6 +8,8 @@ locals {
 }
 
 resource "aws_cloudfront_distribution" "chriswachira_cf_distribution" {
+  provider = aws.us_east_1
+
   origin {
     domain_name = aws_s3_bucket.chriswachira-site-bucket.bucket_regional_domain_name
     origin_id   = local.cw_com_s3_origin_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,3 +19,8 @@ terraform {
 provider "aws" {
   region = "eu-west-1"
 }
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}


### PR DESCRIPTION
Our CloudFront distribution MUST be in the `us-east-1` region to allow mapping a DNS record to it on Route 53